### PR TITLE
Update order API specifications

### DIFF
--- a/APISpecification.md
+++ b/APISpecification.md
@@ -44,7 +44,7 @@ Allergens = { Meat, Diary, Nuts, Gluten, Nuts, Soy, Other } `
   * orderID : int 
   * resturantID : int 
   * numMenuItems : int 
-  * OrderItem[] : {MenuItem, noteToChef: text, addons[MenuItem]}
+  * OrderItem[] : {MenuItem, noteToChef: text}
   * chargeAmmount : float
   * customerName : string
   * [customizations] : text
@@ -128,7 +128,7 @@ The documentation follows this style:
       * customerID
       * chargeAmount
       * tableID
-      * OrderItem[] : {MenuItem, noteToChef: text, addons[MenuItem]}
+      * OrderItem[] : {MenuItem, noteToChef: text}
       * customizations : text
     * Response: 
       * orderID 

--- a/APISpecification.md
+++ b/APISpecification.md
@@ -44,7 +44,7 @@ Allergens = { Meat, Diary, Nuts, Gluten, Nuts, Soy, Other } `
   * orderID : int 
   * resturantID : int 
   * numMenuItems : int 
-  * items[] : MenuItem[]
+  * OrderItem[] : {MenuItem, noteToChef: text, addons[MenuItem]}
   * chargeAmmount : float
   * customerName : string
   * [customizations] : text
@@ -128,7 +128,7 @@ The documentation follows this style:
       * customerID
       * chargeAmount
       * tableID
-      * items : MenuItems[] 
+      * OrderItem[] : {MenuItem, noteToChef: text, addons[MenuItem]}
       * customizations : text
     * Response: 
       * orderID 


### PR DESCRIPTION
An order can contain multiple OrderItem objects. Each OrderItem object will contain 1 MenuItem (i.e. Patty Melt), a note to the chef (if there is no note, it will be left blank) and a list of addons (i.e. French Fries, Side Salad....I am not sure if these will still be MenuItem type, or a different type).